### PR TITLE
Allow dismissing in the opposite direction as presenting

### DIFF
--- a/CNPPopupController/CNPPopupController.m
+++ b/CNPPopupController/CNPPopupController.m
@@ -258,7 +258,7 @@ extern CNPTopBottomPadding CNPTopBottomPaddingMake(CGFloat top, CGFloat bottom) 
     }
     
     [self setUpPopup];
-    [self setDismissedConstraints];
+    [self setOriginConstraints];
     [self needsUpdateConstraints];
     [self layoutIfNeeded];
     [self setPresentedConstraints];
@@ -288,8 +288,12 @@ extern CNPTopBottomPadding CNPTopBottomPaddingMake(CGFloat top, CGFloat bottom) 
 }
 
 - (void)dismissPopupControllerAnimated:(BOOL)flag withButtonTitle:(NSString *)title {
-    
-    [self setDismissedConstraints];
+
+    if (self.theme.dismissesOppositeDirection) {
+        [self setDismissedConstraints];
+    } else {
+        [self setOriginConstraints];
+    }
     
     if ([self.delegate respondsToSelector:@selector(popupController:willDismissWithButtonTitle:)]) {
         [self.delegate popupController:self willDismissWithButtonTitle:title];
@@ -314,8 +318,8 @@ extern CNPTopBottomPadding CNPTopBottomPaddingMake(CGFloat top, CGFloat bottom) 
                      }];
 }
 
-- (void)setDismissedConstraints {
-    
+- (void)setOriginConstraints {
+
     if (self.theme.popupStyle == CNPPopupStyleCentered) {
         switch (self.theme.presentationStyle) {
             case CNPPopupPresentationStyleFadeIn:
@@ -337,6 +341,41 @@ extern CNPTopBottomPadding CNPTopBottomPaddingMake(CGFloat top, CGFloat bottom) 
             case CNPPopupPresentationStyleSlideInFromRight:
                 self.contentViewCenterYConstraint.constant = 0;
                 self.contentViewCenterXConstraint.constant = self.applicationKeyWindow.bounds.size.height;
+                break;
+            default:
+                self.contentViewCenterYConstraint.constant = 0;
+                self.contentViewCenterXConstraint.constant = 0;
+                break;
+        }
+    }
+    else if (self.theme.popupStyle == CNPPopupStyleActionSheet) {
+        self.contentViewBottom.constant = self.applicationKeyWindow.bounds.size.height;
+    }
+}
+
+- (void)setDismissedConstraints {
+    
+    if (self.theme.popupStyle == CNPPopupStyleCentered) {
+        switch (self.theme.presentationStyle) {
+            case CNPPopupPresentationStyleFadeIn:
+                self.contentViewCenterYConstraint.constant = 0;
+                self.contentViewCenterXConstraint.constant = 0;
+                break;
+            case CNPPopupPresentationStyleSlideInFromTop:
+                self.contentViewCenterYConstraint.constant = self.applicationKeyWindow.bounds.size.height;
+                self.contentViewCenterXConstraint.constant = 0;
+                break;
+            case CNPPopupPresentationStyleSlideInFromBottom:
+                self.contentViewCenterYConstraint.constant = -self.applicationKeyWindow.bounds.size.height;
+                self.contentViewCenterXConstraint.constant = 0;
+                break;
+            case CNPPopupPresentationStyleSlideInFromLeft:
+                self.contentViewCenterYConstraint.constant = 0;
+                self.contentViewCenterXConstraint.constant = self.applicationKeyWindow.bounds.size.height;
+                break;
+            case CNPPopupPresentationStyleSlideInFromRight:
+                self.contentViewCenterYConstraint.constant = 0;
+                self.contentViewCenterXConstraint.constant = -self.applicationKeyWindow.bounds.size.height;
                 break;
             default:
                 self.contentViewCenterYConstraint.constant = 0;

--- a/CNPPopupController/CNPPopupTheme.h
+++ b/CNPPopupController/CNPPopupTheme.h
@@ -42,6 +42,7 @@ typedef NS_ENUM(NSInteger, CNPPopupMaskType) {
 @property (nonatomic, assign) UIEdgeInsets popupContentInsets; // Inset of labels, images and buttons on the popup content view (Default 16.0 on all sides)
 @property (nonatomic, assign) CNPPopupStyle popupStyle; // How the popup looks once presented (Default centered)
 @property (nonatomic, assign) CNPPopupPresentationStyle presentationStyle; // How the popup is presented (Defauly slide in from bottom)
+@property (nonatomic, assign) BOOL dismissesOppositeDirection; // If presented from a direction, should it dismiss in the opposite? (Defaults to NO. i.e. Goes back the way it came in)
 @property (nonatomic, assign) CNPPopupMaskType maskType; // Backgound mask of the popup (Default dimmed)
 @property (nonatomic, assign) BOOL shouldDismissOnBackgroundTouch; // Popup should dismiss on tapping on background mask (Default yes)
 @property (nonatomic, assign) CGFloat contentVerticalPadding; // Spacing between each vertical element (Default 12.0)

--- a/CNPPopupController/CNPPopupTheme.m
+++ b/CNPPopupController/CNPPopupTheme.m
@@ -21,6 +21,7 @@
     defaultTheme.popupContentInsets = UIEdgeInsetsMake(16.0f, 16.0f, 16.0f, 16.0f);
     defaultTheme.popupStyle = CNPPopupStyleCentered;
     defaultTheme.presentationStyle = CNPPopupPresentationStyleSlideInFromBottom;
+    defaultTheme.dismissesOppositeDirection = NO;
     defaultTheme.maskType = CNPPopupMaskTypeDimmed;
     defaultTheme.shouldDismissOnBackgroundTouch = YES;
     defaultTheme.contentVerticalPadding = 12.0f;

--- a/CNPPopupControllerExample/Info.plist
+++ b/CNPPopupControllerExample/Info.plist
@@ -19,7 +19,7 @@
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>137</string>
+	<string>142</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/CNPPopupControllerExample/ViewController.m
+++ b/CNPPopupControllerExample/ViewController.m
@@ -45,6 +45,8 @@
     CNPPopupController *popupController = [[CNPPopupController alloc] initWithTitle:title contents:@[lineOne, icon, lineTwo] buttonTitles:@[buttonTitle] destructiveButtonTitle:nil];
     popupController.theme = [CNPPopupTheme defaultTheme];
     popupController.theme.popupStyle = popupStyle;
+    popupController.theme.presentationStyle = CNPPopupPresentationStyleSlideInFromTop;
+    popupController.theme.dismissesOppositeDirection = YES;
     popupController.delegate = self;
     [popupController presentPopupControllerAnimated:YES];
 }


### PR DESCRIPTION
If you set `theme.dismissesOppositeDirection = YES`, then the dismissal of a directionally presented centered panel will go in the opposite direction. So present from top -> dismiss out the bottom. Present from left -> dismiss out the right. Defaults to NO as that is a non breaking change.
