### PR TITLE
Added Swift example code in gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Available in [Cocoa Pods](http://cocoapods.org/?q=CNPPopupController)
 
 ##Usage
 
-(See sample Xcode project in `/CNPPopupControllerExample`)
+See sample Xcode project in `/CNPPopupControllerExample`. For a **Swift** version of the example view controller [see this Gist](https://gist.github.com/lifeisfoo/fe3bc1cc94a137b697aa).
+
 
 ## Creating a Popup
 


### PR DESCRIPTION
I'm using your great component in a Swift project. Since I can't find an example in Swift, I've published a rewrite of your controller in the gist.

Initially I've tried adding this view controller directly inside the example project, but to have swift support too many (and not so useful) changes were needed:
* build target ios >=7
* bridging header
* duplicate the view controller

So I think it's better to have, for now, the Swift example code in the Gist.