### PR TITLE
renamed function to prevent name collision

### DIFF
--- a/CNPPopupController/CNPPopupController.m
+++ b/CNPPopupController/CNPPopupController.m
@@ -85,7 +85,7 @@ static inline UIViewAnimationOptions UIViewAnimationCurveToAnimationOptions(UIVi
 - (void)orientationChanged {
     
     UIInterfaceOrientation statusBarOrientation = [UIApplication sharedApplication].statusBarOrientation;
-    CGFloat angle = UIInterfaceOrientationAngleOfOrientation(statusBarOrientation);
+    CGFloat angle = CNP_UIInterfaceOrientationAngleOfOrientation(statusBarOrientation);
     CGAffineTransform transform = CGAffineTransformMakeRotation(angle);
     
     [UIView animateWithDuration:0.3 animations:^{
@@ -97,7 +97,7 @@ static inline UIViewAnimationOptions UIViewAnimationCurveToAnimationOptions(UIVi
     }];
 }
 
-CGFloat UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orientation)
+CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orientation)
 {
     CGFloat angle;
     


### PR DESCRIPTION
I had a problem "duplicate symbols" issue in my app: another pod also uses the function "UIInterfaceOrientationAngleOfOrientation()". To fix it, I renamed this function in CNPPopupController to "CNP_UIInterfaceOrientationAngleOfOrientation()". 
In general, you should never create functions without a prefix specific to your module (pod)! Especially, don't create function that start with "UI...".