### PR TITLE
Add top corner radius for actionSheet style

### DIFF
--- a/CNPPopupController/CNPPopupController.h
+++ b/CNPPopupController/CNPPopupController.h
@@ -79,6 +79,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGFloat contentVerticalPadding; // Spacing between each vertical element (Default 12.0)
 @property (nonatomic, assign) CGFloat maxPopupWidth; // Maxiumum width that the popup should be (Default 300)
 @property (nonatomic, assign) CGFloat animationDuration; // Duration of presentation animations (Default 0.3s)
+@property (nonatomic, assign) CGFloat popupTopCornerRadius; // topLeft/topRight corner radius of the popup when popupStyle is actionSheet (Default 0.0)
 
 // Factory method to help build a default theme
 + (CNPPopupTheme *)defaultTheme;

--- a/CNPPopupController/CNPPopupController.m
+++ b/CNPPopupController/CNPPopupController.m
@@ -203,6 +203,23 @@ CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orie
     return [self calculateContentSizeThatFits:size andUpdateLayout:NO];
 }
 
+- (CALayer *)buildCornerMaskLayer
+{
+    if (self.theme.popupTopCornerRadius < 0 || self.theme.popupStyle != CNPPopupStyleActionSheet) {
+        return nil;
+    }
+
+    UIBezierPath *maskPath = [UIBezierPath bezierPathWithRoundedRect:self.popupView.bounds
+                                                   byRoundingCorners:(UIRectCornerTopLeft | UIRectCornerTopRight)
+                                                         cornerRadii:CGSizeMake(self.theme.popupTopCornerRadius,
+                                                                                self.theme.popupTopCornerRadius)];
+
+    CAShapeLayer *maskLayer = [[CAShapeLayer alloc] init];
+    maskLayer.frame = self.popupView.bounds;
+    maskLayer.path  = maskPath.CGPath;
+    return maskLayer;
+}
+
 #pragma mark - Keyboard 
 
 - (void)keyboardWillShow:(NSNotification*)notification
@@ -265,6 +282,7 @@ CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orie
     self.popupView.center = [self originPoint];
     [self.applicationWindow addSubview:self.maskView];
     self.maskView.alpha = 0;
+    self.popupView.layer.mask = [self buildCornerMaskLayer];
     [UIView animateWithDuration:flag?self.theme.animationDuration:0.0 animations:^{
         self.maskView.alpha = 1.0;
         self.popupView.center = [self endingPoint];;
@@ -285,6 +303,7 @@ CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orie
         self.popupView.center = [self dismissedPoint];;
     } completion:^(BOOL finished) {
         [self.maskView removeFromSuperview];
+        self.popupView.layer.mask = nil;
         if ([self.delegate respondsToSelector:@selector(popupControllerDidDismiss:)]) {
             [self.delegate popupControllerDidDismiss:self];
         }
@@ -423,6 +442,7 @@ CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orie
     defaultTheme.contentVerticalPadding = 16.0f;
     defaultTheme.maxPopupWidth = 300.0f;
     defaultTheme.animationDuration = 0.3f;
+    defaultTheme.popupTopCornerRadius = 0.0f;
     return defaultTheme;
 }
 

--- a/CNPPopupControllerExample/ViewController.m
+++ b/CNPPopupControllerExample/ViewController.m
@@ -66,6 +66,7 @@
     self.popupController = [[CNPPopupController alloc] initWithContents:@[titleLabel, lineOneLabel, imageView, lineTwoLabel, customView, button]];
     self.popupController.theme = [CNPPopupTheme defaultTheme];
     self.popupController.theme.popupStyle = popupStyle;
+    self.popupController.theme.popupTopCornerRadius = 12.0f;
     self.popupController.delegate = self;
     [self.popupController presentPopupControllerAnimated:YES];
 }

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ A `CNPPopupTheme` instance can be created and assigned to the `theme` property o
 
 `@property (nonatomic, assign) CGFloat animationDuration;`
 
+`@property (nonatomic, assign) CGFloat popupTopCornerRadius;`
+
 ## Notes
 
 ### Deployment


### PR DESCRIPTION
The result will be like this:

![screen shot 2017-01-13 at 11 54 45 am](https://cloud.githubusercontent.com/assets/4200743/21918738/2138b17e-d987-11e6-9b94-43b0762783f7.png)

This corner radius only applied when style is actionSheet and won't affect corner radius of centered popup.