### PR TITLE
Fix popup width larger than application window width on iPad

### DIFF
--- a/CNPPopupController/CNPPopupController.m
+++ b/CNPPopupController/CNPPopupController.m
@@ -358,8 +358,7 @@ CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orie
 - (CGFloat)popupWidth {
     CGFloat width = self.theme.maxPopupWidth;
     CGFloat maskViewWidth = self.maskView.bounds.size.width;
-    if ((self.theme.popupStyle == CNPPopupStyleActionSheet && width > maskViewWidth)
-        || self.theme.popupStyle == CNPPopupStyleFullscreen) {
+    if (width > maskViewWidth || self.theme.popupStyle == CNPPopupStyleFullscreen) {
         width = maskViewWidth;
     }
     return width;

--- a/CNPPopupController/CNPPopupController.m
+++ b/CNPPopupController/CNPPopupController.m
@@ -357,8 +357,10 @@ CGFloat CNP_UIInterfaceOrientationAngleOfOrientation(UIInterfaceOrientation orie
 
 - (CGFloat)popupWidth {
     CGFloat width = self.theme.maxPopupWidth;
-    if ((self.theme.popupStyle == CNPPopupStyleActionSheet && !CNP_IS_IPAD ) || self.theme.popupStyle == CNPPopupStyleFullscreen) {
-        width = self.maskView.bounds.size.width;
+    CGFloat maskViewWidth = self.maskView.bounds.size.width;
+    if ((self.theme.popupStyle == CNPPopupStyleActionSheet && width > maskViewWidth)
+        || self.theme.popupStyle == CNPPopupStyleFullscreen) {
+        width = maskViewWidth;
     }
     return width;
 }


### PR DESCRIPTION
With [Split View and Slide Over](https://support.apple.com/en-us/HT202070) feature on iPad, we can't check if `!CNP_IS_IPAD` and set popup width to `maskView` width. If `maxPopupWidth` is larger than `maskView` width then popup will be clipped.

// UPDATE: Just realized this happened with center style too, so I added one more commit.

Before:

![simulator screen shot jan 16 2017 9 30 09 am](https://cloud.githubusercontent.com/assets/4200743/21969170/8b2bbe66-dbce-11e6-909c-4e72e1ff7995.png)

After:

![simulator screen shot jan 16 2017 9 30 39 am](https://cloud.githubusercontent.com/assets/4200743/21969171/8fbbe99c-dbce-11e6-9e05-db15200a258c.png)
